### PR TITLE
Add feature: added a *.env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ web_modules/
 
 # dotenv environment variable files
 .env
+*.env
 .env.development.local
 .env.test.local
 .env.production.local


### PR DESCRIPTION
Added *.env to gitignore to prevent exposing the .env content in the repo. These are typically sensitive data.